### PR TITLE
yarn installに関する注釈を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 $ git clone git@github.com:DiveintoCode-corp/diveintopost-rails6.git
 $ cd diveintopost-rails6
 $ bundle install --path vendor/bundle
-$ yarn install # まだ環境にyarnが入っていなかったら
+$ yarn install
 $ rails db:create db:migrate
 $ rails db:seed_fu
 ```


### PR DESCRIPTION
yarn installを実行しなければ、node_modulesが生成されず、
node_modulesが生成されない状態で`bin/webpack-dev-server`を実行しても
`Command "webpack-dev-server" not found`のエラーになることを検証で確認しました。